### PR TITLE
docusaurus.config.jsファイルでナビゲーションメニューのラベルを修正

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -78,7 +78,7 @@ const config = {
         style: "dark",
         links: [
           {
-            label: "Portfolio",
+            label: "Homepage",
             to: "https://portfolio.skapp.dev/",
           },
           {


### PR DESCRIPTION
docusaurus.config.js
- ナビゲーションメニューのラベルを"Portfolio"から"Homepage"に変更