### PR TITLE
HomepageBadgesコンポーネントのリンク先を修正

### DIFF
--- a/src/components/HomepageBadges/index.js
+++ b/src/components/HomepageBadges/index.js
@@ -29,7 +29,7 @@ const BadgeList = [
     img: "app-store-badge.png",
   },
   {
-    href: "https://play.google.com/store/apps/details?id=dev.skapp.ai_flash_card",
+    href: "https://play.google.com/store/apps/details?id=ankiapp.site.ai_flash_card",
     img: "google-play-badge.png",
   },
   {


### PR DESCRIPTION
src/components/HomepageBadges/index.js
- play.google.comのリンク先を"dev.skapp.ai_flash_card"から"ankiapp.site.ai_flash_card"に変更